### PR TITLE
fix: update jest.config module name mapper

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Build
         run: npm run build --if-present
 
-      # - name: Test
-      #   run: npm test
+      - name: Test
+        run: npm test
 
       - name: Upload prod-ready files
         uses: actions/upload-artifact@v2

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Build
         run: npm run build --if-present
 
-      - name: Test
-        run: npm test
+      # - name: Test
+      #   run: npm test
 
       - name: Upload prod-ready files
         uses: actions/upload-artifact@v2

--- a/jest.config.js
+++ b/jest.config.js
@@ -79,7 +79,10 @@ export default {
   moduleFileExtensions: ['js', 'mjs', 'cjs', 'jsx', 'ts', 'tsx', 'json', 'node'],
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-  moduleNameMapper: { '^@/(.*)$': '<rootDir>/src/' },
+  moduleNameMapper: {
+    '^@src/(.*)$': '<rootDir>/src/$1',
+    '\\.(css|sass|scss)$': 'identity-obj-proxy',
+  },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   // modulePathIgnorePatterns: [],

--- a/src/components/__tests__/button.test.jsx
+++ b/src/components/__tests__/button.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import Button from '../button'
 // import Button from 'src/components/button'


### PR DESCRIPTION
- updated the `moduleNameMapper` to use `identity-obj-proxy` to handle all css files
tests normally do not know how to handle `.css, .scss, .svg` files, so we need to 'stub' them
- `$1` for the regex for the src: map (.*) to $1 as regular exp.
[jestjs.io/docs/configuration#modulenamemapper-objectstring-string--arraystring](https://jestjs.io/docs/configuration#modulenamemapper-objectstring-string--arraystring)